### PR TITLE
[Fix] Handle Error when deleting too many repositories

### DIFF
--- a/src/pages/unfork/index.tsx
+++ b/src/pages/unfork/index.tsx
@@ -59,6 +59,14 @@ export default function Unfork({ user, providerToken, repos = [] }: Props) {
           method: `DELETE`,
         },
       );
+
+      // Handle error if response is outside the range 200 - 299
+      if(!res.ok) {
+        const message = `An error has occured: ${res.status}`
+        Popup.fire(message)
+        throw new Error(message)
+      }
+
       const resBody = await res.json();
       const numReposDeleted = resBody.data.length;
       Popup.fire(

--- a/src/pages/unfork/index.tsx
+++ b/src/pages/unfork/index.tsx
@@ -17,6 +17,7 @@ import { RepoOption } from '../../types/select';
 import { splitArrayInChunks } from '@/utils/splitArrayInChunks'
 
 const Popup = withReactContent(Swal);
+const NUMBER_OF_REPOS_PER_CHUNK = 5
 interface Props {
   user: User;
   providerToken: string;
@@ -54,7 +55,7 @@ export default function Unfork({ user, providerToken, repos = [] }: Props) {
       setLoading(true);
 
       // Split the total of repos into smaller chunks to process
-      const reposInChunks = splitArrayInChunks(selectedItems, 5);
+      const reposInChunks = splitArrayInChunks(selectedItems, NUMBER_OF_REPOS_PER_CHUNK);
 
       let counter = 0;
       let totalNumReposDeleted = 0;

--- a/src/utils/splitArrayInChunks.ts
+++ b/src/utils/splitArrayInChunks.ts
@@ -1,0 +1,12 @@
+export const splitArrayInChunks = (items: any[], size: number) => {
+    const chunks: any[] = []
+    items = [].concat(...items)
+
+    while (items.length) {
+      chunks.push(
+        items.splice(0, size)
+      )
+    }
+
+    return chunks
+  }


### PR DESCRIPTION
**Notes**: 
This is untested as I do not know where to add additional auth URLs ([Under Setup](https://github.com/lyqht/Octokit-lite/blob/main/CONTRIBUTING.md#setting-up-the-project-for-development)) and what values to fill in to register a new OAuth application.

![Screenshot 2022-12-15 at 12 16 39 AM](https://user-images.githubusercontent.com/6391234/207649826-1b16df85-6e8e-4279-a48e-abe3843fdd8b.png)

**Assumptions**:
As the GitHub API documentation does not specifically indicate the rate limit for the number of deletions one can do at a time, [only a total number of rate limits](https://docs.github.com/en/rest/rate-limit?apiVersion=2022-11-28), I am going with the assumption to group/chunk the repos. 

I have also included a popup message to display an error message if the HTTP response is outside the `200 - 299` range. [The documentation contains a list of codes that are being used](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#delete-a-repository). 

**Others**
Is there a testing library we could use to write tests?

**Fixes Issue:**
https://github.com/lyqht/Octokit-lite/issues/3